### PR TITLE
ticket 19, FE ui - my-requests

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import Login from './pages/Login/Login';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
+import Bookings from './pages/Bookings/Bookings';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
@@ -22,6 +23,9 @@ function App(): JSX.Element {
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path="/dashboard">
                   <Dashboard />
+                </Route>
+                <Route exact path="/bookings">
+                  <Bookings />
                 </Route>
                 <Route path="*">
                   <Redirect to="/login" />

--- a/client/src/components/AuthMenu/AuthMenu.tsx
+++ b/client/src/components/AuthMenu/AuthMenu.tsx
@@ -4,11 +4,13 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import { useAuth } from '../../context/useAuthContext';
+import { useHistory } from 'react-router';
 
 const AuthMenu = (): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const { logout } = useAuth();
+  const history = useHistory();
 
   const handleClick = (event: MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -21,6 +23,10 @@ const AuthMenu = (): JSX.Element => {
   const handleLogout = () => {
     handleClose();
     logout();
+  };
+
+  const handleBookings = () => {
+    history.push('/bookings');
   };
 
   return (
@@ -41,6 +47,7 @@ const AuthMenu = (): JSX.Element => {
         getContentAnchorEl={null}
       >
         <MenuItem onClick={handleLogout}>Logout</MenuItem>
+        <MenuItem onClick={handleBookings}>Bookings</MenuItem>
       </Menu>
     </div>
   );

--- a/client/src/pages/Bookings/Bookings.tsx
+++ b/client/src/pages/Bookings/Bookings.tsx
@@ -3,7 +3,6 @@ import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
-import CssBaseline from '@material-ui/core/CssBaseline';
 import Typography from '@material-ui/core/Typography';
 import CardHeader from '@material-ui/core/CardHeader';
 import Settings from '@material-ui/icons/Settings';
@@ -23,6 +22,7 @@ export default function Bookings(): JSX.Element {
     currentMonth: boolean,
     DayComponent: ReactElement,
   ) => {
+    // TODO: for implementing on ticket 31
     // const days = day ? day.getTime() : null;
     // const stateDays = dateReqs.filter((el) => el.accepted).map((el) => new Date(el.start).getTime());
     // if (days === stateDays.find((el) => el === days && days >= selectedDate.getTime())) {
@@ -37,7 +37,7 @@ export default function Bookings(): JSX.Element {
         <Grid item xs={5} className={classes.bookingsList} container direction={'column'} spacing={1}>
           <Grid item>
             <Card elevation={2} className={classes.bookingsCardNext}>
-              <Typography className={classes.typographyCurrent}>YOUR NEXT BOOKING:</Typography>
+              <Typography className={classes.typographyCurrent}>Your next booking:</Typography>
               <CardContent className={classes.bookingsCardContent}>
                 <Typography variant={'h6'} noWrap display={'inline'}>
                   17 Sept 2021, 10-12AM
@@ -50,7 +50,7 @@ export default function Bookings(): JSX.Element {
 
           <Grid item>
             <Card elevation={2} className={classes.bookingsCardContainer}>
-              <Typography className={classes.typographyCurrent}>CURRENT BOOKINGS:</Typography>
+              <Typography className={classes.typographyCurrent}>Current bookings:</Typography>
               <Box className={classes.scrollableBox}>
                 <Card variant={'outlined'} className={classes.bookingsCardItem}>
                   <CardContent className={classes.bookingsCardContent}>
@@ -62,7 +62,7 @@ export default function Bookings(): JSX.Element {
                   <CardHeader avatar={'avatar'} title={'logan test name'} action={'status'} />
                 </Card>
 
-                <Typography className={classes.typographyPast}>PAST BOOKINGS:</Typography>
+                <Typography className={classes.typographyPast}>Past bookings:</Typography>
                 <Card variant={'outlined'} className={classes.bookingsCardItem}>
                   <CardContent className={classes.bookingsCardContent}>
                     <Typography variant={'h6'} noWrap display={'inline'}>

--- a/client/src/pages/Bookings/Bookings.tsx
+++ b/client/src/pages/Bookings/Bookings.tsx
@@ -1,0 +1,96 @@
+import useStyles from './useStyles';
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Typography from '@material-ui/core/Typography';
+import CardHeader from '@material-ui/core/CardHeader';
+import Settings from '@material-ui/icons/Settings';
+import Box from '@material-ui/core/Box';
+import { MuiPickersUtilsProvider, DatePicker } from '@material-ui/pickers';
+import DateFnsUtils from '@date-io/date-fns';
+import { useState } from 'react';
+
+export default function Bookings(): JSX.Element {
+  const classes = useStyles();
+  const [selectedDate, handleDateChange] = useState<Date>(new Date());
+  //in the next ticket this dateTester will be hooked up to an API call that retrieves all the dates from the database, currently it is only 1 date to test-display the selected calendar view
+  const dateTester = useState<Date>(new Date('09/13/2021'));
+
+  return (
+    <Grid container className={`${classes.root}`}>
+      <CssBaseline />
+      <Grid xs={12} item className={classes.bookingsWrapper} container>
+        <Grid item xs={5} className={classes.bookingsList} container direction={'column'} spacing={1}>
+          <Grid item>
+            <Card elevation={2} className={classes.bookingsCardNext}>
+              <Typography className={classes.typographyCurrent}>YOUR NEXT BOOKING:</Typography>
+              <CardContent className={classes.bookingsCardContent}>
+                <Typography variant={'h6'} noWrap display={'inline'}>
+                  17 Sept 2021, 10-12AM
+                </Typography>
+                <Settings className={classes.iconSettings} />
+              </CardContent>
+              <CardHeader avatar={'avatar'} title={'logan test name'} action={'status'} />
+            </Card>
+          </Grid>
+
+          <Grid item>
+            <Card elevation={2} className={classes.bookingsCardContainer}>
+              <Typography className={classes.typographyCurrent}>CURRENT BOOKINGS:</Typography>
+              <Box className={classes.scrollableBox}>
+                {/* forEach will come from db array of requests that are upcoming*/}
+                <Card variant={'outlined'} className={classes.bookingsCardItem}>
+                  <CardContent className={classes.bookingsCardContent}>
+                    <Typography variant={'h6'} noWrap display={'inline'}>
+                      17 Sept 2021, 10-12AM
+                    </Typography>
+                    <Settings className={classes.iconSettings} />
+                  </CardContent>
+                  <CardHeader avatar={'avatar'} title={'logan test name'} action={'status'} />
+                </Card>
+                {/* end of forEach*/}
+
+                <Typography className={classes.typographyPast}>PAST BOOKINGS:</Typography>
+                {/* forEach will come from db array of requests that are past*/}
+                <Card variant={'outlined'} className={classes.bookingsCardItem}>
+                  <CardContent className={classes.bookingsCardContent}>
+                    <Typography variant={'h6'} noWrap display={'inline'}>
+                      17 Sept 2021, 10-12AM
+                    </Typography>
+                    <Settings className={classes.iconSettings} />
+                  </CardContent>
+                  <CardHeader avatar={'avatar'} title={'logan test name'} action={'status'} />
+                </Card>
+                {/* end of forEach*/}
+              </Box>
+            </Card>
+          </Grid>
+        </Grid>
+        <Grid item xs={7} className={classes.bookingsCalendar} direction={'column'}>
+          <Paper elevation={2} className={classes.calendarContainer}>
+            <MuiPickersUtilsProvider utils={DateFnsUtils}>
+              <DatePicker
+                autoOk
+                disableToolbar
+                orientation="landscape"
+                variant="static"
+                value={selectedDate}
+                disabled
+                renderDay={(day, selectedDay, currentMonth, DayComponent) => {
+                  const tests = day ? day.getTime() : null;
+                  if (tests === dateTester[0].getTime()) {
+                    return <div className={classes.customSelectedDay}>{DayComponent}</div>;
+                  }
+                  return DayComponent;
+                }}
+                onChange={() => handleDateChange(new Date())}
+              />
+            </MuiPickersUtilsProvider>
+          </Paper>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/pages/Bookings/Bookings.tsx
+++ b/client/src/pages/Bookings/Bookings.tsx
@@ -10,17 +10,29 @@ import Settings from '@material-ui/icons/Settings';
 import Box from '@material-ui/core/Box';
 import { MuiPickersUtilsProvider, DatePicker } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
-import { useState } from 'react';
+import { ReactElement, useState } from 'react';
 
 export default function Bookings(): JSX.Element {
   const classes = useStyles();
   const [selectedDate, handleDateChange] = useState<Date>(new Date());
-  //in the next ticket this dateTester will be hooked up to an API call that retrieves all the dates from the database, currently it is only 1 date to test-display the selected calendar view
   const dateTester = useState<Date>(new Date('09/13/2021'));
+
+  const renderDayCalendar = (
+    day: Date | null,
+    selectedDay: Date | null,
+    currentMonth: boolean,
+    DayComponent: ReactElement,
+  ) => {
+    // const days = day ? day.getTime() : null;
+    // const stateDays = dateReqs.filter((el) => el.accepted).map((el) => new Date(el.start).getTime());
+    // if (days === stateDays.find((el) => el === days && days >= selectedDate.getTime())) {
+    //   return <div className={classes.customSelectedDay}>{DayComponent}</div>;
+    // }
+    return DayComponent;
+  };
 
   return (
     <Grid container className={`${classes.root}`}>
-      <CssBaseline />
       <Grid xs={12} item className={classes.bookingsWrapper} container>
         <Grid item xs={5} className={classes.bookingsList} container direction={'column'} spacing={1}>
           <Grid item>
@@ -40,7 +52,6 @@ export default function Bookings(): JSX.Element {
             <Card elevation={2} className={classes.bookingsCardContainer}>
               <Typography className={classes.typographyCurrent}>CURRENT BOOKINGS:</Typography>
               <Box className={classes.scrollableBox}>
-                {/* forEach will come from db array of requests that are upcoming*/}
                 <Card variant={'outlined'} className={classes.bookingsCardItem}>
                   <CardContent className={classes.bookingsCardContent}>
                     <Typography variant={'h6'} noWrap display={'inline'}>
@@ -50,10 +61,8 @@ export default function Bookings(): JSX.Element {
                   </CardContent>
                   <CardHeader avatar={'avatar'} title={'logan test name'} action={'status'} />
                 </Card>
-                {/* end of forEach*/}
 
                 <Typography className={classes.typographyPast}>PAST BOOKINGS:</Typography>
-                {/* forEach will come from db array of requests that are past*/}
                 <Card variant={'outlined'} className={classes.bookingsCardItem}>
                   <CardContent className={classes.bookingsCardContent}>
                     <Typography variant={'h6'} noWrap display={'inline'}>
@@ -63,7 +72,6 @@ export default function Bookings(): JSX.Element {
                   </CardContent>
                   <CardHeader avatar={'avatar'} title={'logan test name'} action={'status'} />
                 </Card>
-                {/* end of forEach*/}
               </Box>
             </Card>
           </Grid>
@@ -78,13 +86,9 @@ export default function Bookings(): JSX.Element {
                 variant="static"
                 value={selectedDate}
                 disabled
-                renderDay={(day, selectedDay, currentMonth, DayComponent) => {
-                  const tests = day ? day.getTime() : null;
-                  if (tests === dateTester[0].getTime()) {
-                    return <div className={classes.customSelectedDay}>{DayComponent}</div>;
-                  }
-                  return DayComponent;
-                }}
+                renderDay={(day, selectedDay, currentMonth, DayComponent) =>
+                  renderDayCalendar(day, selectedDay, currentMonth, DayComponent)
+                }
                 onChange={() => handleDateChange(new Date())}
               />
             </MuiPickersUtilsProvider>

--- a/client/src/pages/Bookings/useStyles.ts
+++ b/client/src/pages/Bookings/useStyles.ts
@@ -57,6 +57,7 @@ const useStyles = makeStyles(() => ({
     fontSize: '10px',
     padding: '10px 0 10px 16px',
     alignSelf: 'start',
+    textTransform: 'uppercase',
   },
   typographyPast: {
     fontWeight: 900,

--- a/client/src/pages/Bookings/useStyles.ts
+++ b/client/src/pages/Bookings/useStyles.ts
@@ -1,0 +1,112 @@
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    minWidth: '100vw',
+  },
+  bookingsWrapper: {
+    backgroundColor: 'rgb(250, 250, 250)',
+  },
+  bookingsList: {
+    padding: '5% 3% 0 3%',
+    display: 'flex',
+    alignItems: 'flex-end',
+  },
+  bookingsCardNext: {
+    width: '320px',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  bookingsCardContainer: {
+    maxHeight: '80vh',
+    width: '320px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  scrollableBox: {
+    paddingRight: '3px',
+    overflowY: 'scroll',
+    '&::-webkit-scrollbar': {
+      width: '4px',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      borderRadius: '3px',
+      height: '50px',
+      backgroundColor: 'rgba(168, 168, 168, 0.7)',
+    },
+  },
+  bookingsCardItem: {
+    alignItems: 'unset',
+    width: '280px',
+    height: '86px',
+    marginBottom: '8px',
+  },
+  bookingsCardContent: {
+    padding: '8px 8px 0 16px',
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  iconSettings: {
+    fill: 'rgba(0,0,0,0.2)',
+    height: '15px',
+    cursor: 'pointer',
+  },
+  typographyCurrent: {
+    fontWeight: 900,
+    fontSize: '10px',
+    padding: '10px 0 10px 16px',
+    alignSelf: 'start',
+  },
+  typographyPast: {
+    fontWeight: 900,
+    fontSize: '10px',
+    padding: '10px 0 10px 0',
+    alignSelf: 'start',
+  },
+  bookingsCalendar: {
+    padding: '5% 3% 0 3%',
+    display: 'flex',
+    justifyContent: 'flex-start',
+  },
+  calendarContainer: {
+    width: '500px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    '& .MuiTypography-body1': {
+      color: 'rgb(240, 69, 69)',
+      fontWeight: '400',
+    },
+    '& .MuiPickersDay-day': {
+      padding: '0 20px',
+    },
+    '& .MuiPickersDay-daySelected': {
+      backgroundColor: 'unset',
+      color: 'unset',
+    },
+    '& .MuiPickersDay-daySelected:hover': {
+      backgroundColor: 'rgb(245, 245, 245)',
+      color: 'unset',
+    },
+    '& .MuiTypography-caption': {
+      padding: '20px',
+      display: 'flex',
+      justifyContent: 'center',
+    },
+    '& .MuiSvgIcon-root': {
+      color: 'rgba(0,0,0,0.2)',
+    },
+  },
+  customSelectedDay: {
+    '& button': {
+      backgroundColor: 'rgb(240, 69, 69)',
+      color: 'white',
+    },
+    '& button:hover': {
+      backgroundColor: 'rgb(240, 69, 69)',
+    },
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
### What this PR does (required):
- This is the 'my requests' ui page for dog sitters.

### Screenshots / Videos (required):
![image](https://user-images.githubusercontent.com/78234668/133937721-3996decd-13d4-47c6-a33c-e6f0e22b6414.png)
![image](https://user-images.githubusercontent.com/78234668/133937733-d2affaa4-ce0b-46e4-a15f-d55d9ce4e836.png)


### Any information needed to test this feature (required):
- run: npm i @material-ui/pickers@3.3.10
- run: npm i @date-io/date-fns@1.x date-fns

### Any issues with the current functionality (optional):
- To access the page, once logged in, there was a menu button temporarily added inside the 'AuthMenu' component, right underneath the logout button that is named "Bookings"
- Currently the Bookings page only uses dummy data that exists within the same page file to display functionality.  There is also no iteration over the data, that will be implemented in the next ticket #31 that fetches DB data and plugs it into the ui.  
